### PR TITLE
Add Twitter's bootstrap toolkit

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -18,8 +18,8 @@
     "version": "1.0"
   },
   "bootstrap": {
-    "url": "https://github.com/twitter/bootstrap/raw/master/bootstrap-1.1.1.css",
-    "compressed": "bootstrap-1.1.1.min.css",
+    "url": "https://github.com/twitter/bootstrap/raw/v{version}/bootstrap-{version}.css",
+    "compressed": "bootstrap-{version}.min.css",
     "description": "CSS toolkit from Twitter",
     "tags": ["css", "twitter"],
     "version": "1.1.1"

--- a/assets.json
+++ b/assets.json
@@ -17,6 +17,29 @@
     ],
     "version": "1.0"
   },
+  "bootstrap": {
+    "url": "https://github.com/twitter/bootstrap/raw/master/bootstrap-1.1.1.css",
+    "compressed": "bootstrap-1.1.1.min.css",
+    "description": "CSS toolkit from Twitter",
+    "tags": ["css", "twitter"],
+    "version": "1.1.1"
+  },
+  "bootstrap-less": {
+    "base": "https://github.com/twitter/bootstrap/raw/v{version}",
+    "description": "CSS toolkit from Twitter (LESS Source)",
+    "tags": ["css", "twitter", "less"],
+    "files": [
+      "lib/bootstrap.less",
+      "lib/forms.less",
+      "lib/patterns.less",
+      "lib/preboot.less",
+      "lib/reset.less",
+      "lib/scaffolding.less",
+      "lib/tables.less",
+      "lib/type.less"
+    ],
+    "version": "1.1.1"
+  },
   "eventemitter2": {
     "url": "https://github.com/hij1nx/EventEmitter2/blob/v{version}/lib/eventemitter2.js",
     "description": "nodejs-style event emitter with namespaces, wildcards, TTL etc",

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -190,7 +190,8 @@ Installer.prototype.download = function(asset, path){
   var self = this
     , version = asset.version
     , url = asset.entry[asset.compress ? 'compressed' : 'url'] || asset.entry.url
-    , url = url.replace(/\{version\}/g, version);
+    , url = url.replace(/\{version\}/g, version)
+    , path = path.replace(/\{version\}/g, version);
 
   // compressed
   if (asset.compress && asset.entry.compressed) {


### PR DESCRIPTION
I just wanted support for [bootstrap](https://github.com/twitter/bootstrap/) in asset.

You can now require `bootstrap` and `bootstrap-less` (the less source version) in your project !
