### PR TITLE
fix to match README syntax

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+0.4.12 / 2012-09-25 
+==================
+
+  * fix to match README syntax (compression option)
+	* added jade-runtime
 
 0.4.11 / 2012-06-13 
 ==================

--- a/assets.json
+++ b/assets.json
@@ -360,5 +360,12 @@
     "description": "Minimal templating with {{mustaches}} in JavaScript",
     "version": "0.3.0",
     "tags": ["js", "templates", "templating"]
+  },
+  "jade-runtime": {
+    "url": "https://github.com/visionmedia/jade/raw/{version}/runtime.js",
+    "description": "jade template engine for client-side use",
+    "compressed": "runtime.min.js",
+    "tags": ["template"],
+    "version": "0.27.4"
   }
 }

--- a/bin/asset
+++ b/bin/asset
@@ -156,7 +156,7 @@ process.on('exit', function(){ console.log(); });
 function assetsFromObject(obj) {
   var arr = [];
   for (var asset in obj) {
-    arr.push({ name: asset, version: obj[asset].version });
+    arr.push({ name: asset, version: obj[asset], compress: options.compress });
   }
   return arr;
 }

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -15,7 +15,7 @@ var Installer = require('./installer');
  * Library version.
  */
 
-exports.version = '0.4.11';
+exports.version = '0.4.12';
 
 /**
  * Install `assets` with `repo` object, and `dest` directory.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {   "name": "asset"
-  , "version": "0.4.11"
+  , "version": "0.4.12"
   , "description": "Asset manager"
   , "keywords": ["assets", "javascript", "css", "package manager"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"


### PR DESCRIPTION
- the asset README indicates that you can specify a ./assets.json like so:
  { "jquery": "1.7.2", "backbone": "0.9.2" }
  but in the code you were expecting this syntax:
  { "jquery": { "version": "1.7.2" }, "backbone": { "version": "0.9.2" } }
  fixed to match README syntax.
- when compress is defined in the ./.asset file, the options isn't accounted for when asset uses the ./assets.json file. fixed.
